### PR TITLE
[WIP] docker volume 経由で fluentd sidecar に送信

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ APP_KEY=base64:p5Fu8gRUOuPUXzY3VcxpnYsUR9f2h8nTSm5JlYkzPTM=
 APP_DEBUG=true
 APP_URL=http://localhost
 
-LOG_CHANNEL=stderr
+LOG_CHANNEL=stack
 
 DB_CONNECTION=mysql
 DB_HOST=mysql

--- a/app/Http/Controllers/BooksController.php
+++ b/app/Http/Controllers/BooksController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use Faker\Factory as Faker;
+use Illuminate\Support\Facades\Log;
 
 use App\Book;
 
@@ -12,11 +13,13 @@ class BooksController extends Controller
 {
     public function index()
     {
+        Log::info("index");
         return response()->json(Book::all());
     }
 
     public function store()
     {
+        Log::info("store");
         $book = new Book();
         $book->title = "tmp title"; // Faker::create()->name();
         $book->save();

--- a/config/logging.php
+++ b/config/logging.php
@@ -48,7 +48,7 @@ return [
 
         'daily' => [
             'driver' => 'daily',
-            'path' => storage_path('logs/laravel.log'),
+            'path' => '/var/log/php/laravel.log',
             'level' => 'debug',
             'days' => 14,
         ],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       dockerfile: docker/nginx/Dockerfile
     volumes:
       - ./public:/var/www/html/public:ro
+      - logvolume:/var/log
     ports:
       - 8001:80
     environment:
@@ -20,8 +21,15 @@ services:
       - DD_AGENT_HOST=datadog
     env_file:
       - .env.example
-    # volumes:
-    #   - .:/var/www/html:cached
+    volumes:
+        - logvolume:/var/log
+
+  fluentd:
+    build:
+      context: docker/fluentd
+      dockerfile: Dockerfile
+    volumes:
+        - logvolume:/var/log
 
   mysql:
     image: mysql:5.7
@@ -32,6 +40,8 @@ services:
       MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
     ports:
       - 3306
+volumes:
+  logvolume:
 
   # datadog:
   #   image: datadog/agent:latest

--- a/docker/fluentd/Dockerfile
+++ b/docker/fluentd/Dockerfile
@@ -1,0 +1,34 @@
+FROM fluent/fluentd:v0.12-onbuild
+
+ARG UNAME=fluent
+ARG APP_GID=1024
+ARG APP_GNAME=appgroup
+
+RUN apk add --update --virtual .build-deps \
+    sudo build-base ruby-dev
+
+# timezone set
+RUN apk --update add tzdata && \
+    cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
+    apk del tzdata
+
+# install plugins
+RUN sudo fluent-gem install \
+    fluent-plugin-kinesis \
+    fluent-plugin-rewrite-tag-filter
+
+# garbage delete
+RUN sudo gem sources --clear-all \
+    && apk del .build-deps \
+    && rm -rf /var/cache/apk/* /home/fluent/.gem/ruby/2.4.0/cache/*.gem
+
+RUN set -x \
+    && apk add --update shadow \
+    && addgroup ${APP_GNAME} -g ${APP_GID} \
+    && usermod -aG ${APP_GNAME} ${UNAME}
+
+# conf copy
+COPY ./fluent.conf /fluentd/etc/fluent.conf
+COPY ./docker-entrypoint.sh /usr/local/bin/docker-init.sh
+
+ENTRYPOINT ["sh", "/usr/local/bin/docker-init.sh"]

--- a/docker/fluentd/docker-entrypoint.sh
+++ b/docker/fluentd/docker-entrypoint.sh
@@ -1,0 +1,1 @@
+exec tini -- /bin/entrypoint.sh fluentd

--- a/docker/fluentd/fluent.conf
+++ b/docker/fluentd/fluent.conf
@@ -1,0 +1,47 @@
+<source>
+  @type tail
+  path /var/log/nginx/site_access.log
+  pos_file /var/log/nginx/site_access.log.pos
+  read_from_head true
+  tag access.proxy.nginx
+  <parse>
+    @type none
+  </parse>
+</source>
+
+<source>
+  @type tail
+  path /var/log/nginx/site_error.log
+  pos_file /var/log/nginx/site_error.log.pos
+  read_from_head true
+  tag error.proxy.nginx
+  <parse>
+    @type none
+  </parse>
+</source>
+
+<source>
+  @type tail
+  path /var/log/php/laravel-%Y-%m-%d.log
+  pos_file /var/log/php/laravel.log.pos
+  read_from_head true
+  tag access.proxy.php
+  <parse>
+    @type none
+  </parse>
+</source>
+
+<source>
+  @type tail
+  path /var/log/php/error.log
+  pos_file /var/log/php/error.log.pos
+  read_from_head true
+  tag error.proxy.php
+  <parse>
+    @type none
+  </parse>
+</source>
+
+<filter **>
+  @type stdout
+</filter>

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,10 +1,20 @@
 FROM nginx:1.15-alpine
 
+ARG UNAME=nginx
+ARG APP_GID=1024
+ARG APP_GNAME=appgroup
+
+RUN set -x \
+    && apk add --update shadow \
+    && addgroup ${APP_GNAME} -g ${APP_GID} \
+    && usermod -aG ${APP_GNAME} ${UNAME}
+
 COPY public /var/www/html/public
 COPY docker/nginx/default.conf.template /etc/nginx/conf.d/default.conf.template
+COPY docker/nginx/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 ENV PHP_HOST=127.0.0.1
 
 EXPOSE 80
 
-CMD /bin/sh -c 'sed "s/\${PHP_HOST}/${PHP_HOST}/" /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf && nginx -g "daemon off;"'
+ENTRYPOINT ["sh", "/usr/local/bin/docker-entrypoint.sh"]

--- a/docker/nginx/default.conf.template
+++ b/docker/nginx/default.conf.template
@@ -1,3 +1,16 @@
+log_format ltsv 'time:$time_local\t'
+        'remote_addr:$remote_addr\t'
+        'x-forwarded-for:$http_x_forwarded_for\t'
+        'user_agent:$http_user_agent\t'
+        'server_ip:$server_addr\t'
+        'method:$request_method\t'
+        'path:$request_uri\t'
+        'query:$query_string\t'
+        'referrer:$http_referer\t'
+        'status:$status\t'
+        'taken_time:$request_time\t';
+
+
 server {
     listen 80;
 
@@ -24,4 +37,7 @@ server {
         fastcgi_param           REQUEST_FILENAME $request_filename;
         include                 fastcgi_params;
     }
+
+    error_log /var/log/nginx/site_error.log warn;
+    access_log /var/log/nginx/site_access.log ltsv;
 }

--- a/docker/nginx/docker-entrypoint.sh
+++ b/docker/nginx/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+set -x \
+    && mkdir -p /var/log/nginx \
+    && chown nginx:appgroup /var/log/nginx \
+    && chmod g+s /var/log/nginx
+
+set -x \
+    && sed "s/\${PHP_HOST}/${PHP_HOST}/" /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf \
+    && exec nginx -g "daemon off;"
+

--- a/docker/php/docker-entrypoint.sh
+++ b/docker/php/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+set -x \
+    && whoami \
+    && mkdir -p /var/log/php \
+    && chmod 775 /var/log/php \
+    && chmod g+s /var/log/php \
+    && chown www:appgroup /var/log/php \
+    && touch /var/log/php/error.log /var/log/php/access.log \
+    && chown www:appgroup /var/log/php/error.log /var/log/php/access.log \
+    && chmod g+r /var/log/php/error.log /var/log/php/access.log
+
+# fix /proc/self/fd/2 in php-fpm.d/docker.conf
+set -x \
+    && sed -i -e 's:error_log =.*:error_log = /var/log/php/error.log:' /usr/local/etc/php-fpm.d/docker.conf \
+    && sed -i -e 's:access\.log =.*:access\.log = /var/log/php/access.log:' /usr/local/etc/php-fpm.d/docker.conf \
+    && cat /usr/local/etc/php-fpm.d/docker.conf
+
+exec gosu www php-fpm

--- a/terraform/container_definitions.json
+++ b/terraform/container_definitions.json
@@ -1,7 +1,7 @@
 [
     {
         "name": "nginx",
-        "image": "${account_id}.dkr.ecr.${region}.amazonaws.com/handson-nginx:${tag}",
+        "image": "${account_id}.dkr.ecr.${region}.amazonaws.com/nginx:${tag}",
         "cpu": 0,
         "memory": 128,
         "portMappings": [
@@ -16,8 +16,72 @@
             "options": {
                 "awslogs-region": "${region}",
                 "awslogs-group": "/${name}/ecs",
-                "awslogs-stream-prefix": "api"
+                "awslogs-stream-prefix": "nginx"
             }
         }
-    }
+    },
+    {
+        "name": "app",
+        "image": "${account_id}.dkr.ecr.${region}.amazonaws.com/app:${tag}",
+        "cpu": 0,
+        "memory": 128,
+        "logConfiguration": {
+            "logDriver": "awslogs",
+            "options": {
+                "awslogs-region": "${region}",
+                "awslogs-group": "/${name}/ecs",
+                "awslogs-stream-prefix": "app"
+            }
+        },
+        "secrets": [
+            {
+                "name": "APP_KEY",
+                "valueFrom": "/handson/app/key"
+            }
+        ],
+        "environment": [
+            {
+                "name": "APP_ENV",
+                "value": "${app_env}"
+            },
+            {
+                "name": "LOG_CHANNEL",
+                "value": "stderr"
+            }
+        ]
+    },
+  {
+    "name": "datadog",
+    "image": "datadog/agent",
+    "cpu": 10,
+    "memory": 256,
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-region": "${region}",
+        "awslogs-group": "/${name}/ecs",
+        "awslogs-stream-prefix": "datadog"
+      }
+    },
+    "secrets": [
+      {
+        "name": "DD_API_KEY",
+        "valueFrom": "/handson/datadog/key"
+      }
+    ],
+    "environment": [
+      {
+        "name": "DD_APM_ENABLED",
+        "value": "true"
+      },
+      {
+        "name": "ECS_FARGATE",
+        "Value": "true"
+      },
+      {
+        "name": "DD_TAGS",
+        "value": "env:${app_env}"
+      }
+    ]
+  }
 ]

--- a/terraform/container_definitions.json
+++ b/terraform/container_definitions.json
@@ -11,28 +11,20 @@
                 "protocol": "tcp"
             }
         ],
-        "logConfiguration": {
-            "logDriver": "awslogs",
-            "options": {
-                "awslogs-region": "${region}",
-                "awslogs-group": "/${name}/ecs",
-                "awslogs-stream-prefix": "nginx"
-            }
-        }
+        "mountPoints": [
+            "sourceVolume": "logvolume",
+            "containerPath": "/var/log/"
+        ]
     },
     {
         "name": "app",
         "image": "${account_id}.dkr.ecr.${region}.amazonaws.com/app:${tag}",
         "cpu": 0,
         "memory": 128,
-        "logConfiguration": {
-            "logDriver": "awslogs",
-            "options": {
-                "awslogs-region": "${region}",
-                "awslogs-group": "/${name}/ecs",
-                "awslogs-stream-prefix": "app"
-            }
-        },
+        "mountPoints": [
+            "sourceVolume": "logvolume",
+            "containerPath": "/var/log/"
+        ],
         "secrets": [
             {
                 "name": "APP_KEY",
@@ -49,6 +41,24 @@
                 "value": "stderr"
             }
         ]
+    },
+    {
+        "name": "fluentd",
+        "image": "${account_id}.dkr.ecr.${region}.amazonaws.com/fluentd:${tag}",
+        "cpu": 0,
+        "memory": 256,
+        "mountPoints": [
+            "sourceVolume": "logvolume",
+            "containerPath": "/var/log/"
+        ],
+        "logConfiguration": {
+            "logDriver": "awslogs",
+            "options": {
+                "awslogs-region": "${region}",
+                "awslogs-group": "/${name}/ecs",
+                "awslogs-stream-prefix": "datadog"
+            }
+        }
     },
   {
     "name": "datadog",

--- a/terraform/container_definitions.json
+++ b/terraform/container_definitions.json
@@ -11,20 +11,20 @@
                 "protocol": "tcp"
             }
         ],
-        "mountPoints": [
+        "mountPoints": [{
             "sourceVolume": "logvolume",
             "containerPath": "/var/log/"
-        ]
+        }]
     },
     {
         "name": "app",
         "image": "${account_id}.dkr.ecr.${region}.amazonaws.com/app:${tag}",
         "cpu": 0,
         "memory": 128,
-        "mountPoints": [
+        "mountPoints": [{
             "sourceVolume": "logvolume",
             "containerPath": "/var/log/"
-        ],
+        }],
         "secrets": [
             {
                 "name": "APP_KEY",
@@ -47,10 +47,10 @@
         "image": "${account_id}.dkr.ecr.${region}.amazonaws.com/fluentd:${tag}",
         "cpu": 0,
         "memory": 256,
-        "mountPoints": [
+        "mountPoints": [{
             "sourceVolume": "logvolume",
             "containerPath": "/var/log/"
-        ],
+        }],
         "logConfiguration": {
             "logDriver": "awslogs",
             "options": {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -141,6 +141,7 @@ data "template_file" "container_definitions" {
     account_id = "${data.aws_caller_identity.self.account_id}"
     region     = "${data.aws_region.current.name}"
     name       = "${var.name}"
+    app_env    = "production"
   }
 }
 

--- a/terraform/modules/ecs-service/main.tf
+++ b/terraform/modules/ecs-service/main.tf
@@ -25,6 +25,10 @@ resource "aws_ecs_task_definition" "this" {
 
   task_role_arn      = "${aws_iam_role.task_execution.arn}"
   execution_role_arn = "${aws_iam_role.task_execution.arn}"
+
+  volume {
+    name = "logvolume"
+  }
 }
 
 resource "aws_iam_role" "task_execution" {


### PR DESCRIPTION
## もともと : 
* aws fargate 
* docker logging driver : awslog

## ログ集計は fluentd → kinesis 経由で集計したいため、本PRを作りました
参考 : https://dev.classmethod.jp/cloud/aws/fargate-fluentd-s3/

## やったこと

* docker volume を使います : `logvolume`
* 各 container のログ: `stderr` をやめて、 `logvolume:/var/log` を使います
    * `fluentd` 自体のログは自分に転送できないので `awslog` にします
* 権限問題 : dockerfile で権限設定しても、docker volume が root 権限のまま、no-root で動くcontainer が権限足りません
    * 各 Dockerfile に `appgroup` の linux group を用意しました
    * 各 Dockerfile で `USER root` にします
    * entrypoint script で volume の dir を chmod / chown して、 `/var/log` を `appgroup` group のユーザーが見えるようにします
    * 最終は各 container に no-root で exec します
        * nginx : root で自動に nginx に切り替えるので問題ありません
        * php-fpm : gosu で `www` のユーザーで `exec php-fpm` します


## TODO : ログローテーション課題
* ログローテーション
    * ecs ボリューム制限 : https://docs.aws.amazon.com/ja_jp/AmazonECS/latest/developerguide/fargate-task-storage.html
ローテーションしないとどんどん用量溜まって最後にエラーになるはずです。

### やり方?
* sidecar : crontab の container を作る
    * nginx/php container に 入って、 ファイル名変更して、USER1 シグナルを送信する?
* 疑問点：
    * 一日一回しか動かしないのに、 わざわざ container を作る？
    * ssh が面倒から、 datadog のように docker.sock を mount して、 docker exec 経由?
    * 他のいい方法があるかな？

